### PR TITLE
Update postresql dependency

### DIFF
--- a/cascading-jdbc-redshift/build.gradle
+++ b/cascading-jdbc-redshift/build.gradle
@@ -20,7 +20,7 @@
 
 evaluationDependsOn( ":cascading-jdbc-core" )
 
-ext.redshiftPostgresVersion = '8.0-318.jdbc3'
+ext.redshiftPostgresVersion = '9.1-901.jdbc4'
 
 dependencies {
 

--- a/cascading-jdbc-redshift/build.gradle
+++ b/cascading-jdbc-redshift/build.gradle
@@ -20,7 +20,7 @@
 
 evaluationDependsOn( ":cascading-jdbc-core" )
 
-ext.redshiftPostgresVersion = '9.1-901.jdbc4'
+ext.redshiftPostgresVersion = '8.4-702.jdbc4'
 
 dependencies {
 


### PR DESCRIPTION
I ran into character encodings problems when reading text fields that contained emoji characters. I found that updating the postgresql dependency to the latest version fixed this and allowed me to read the data without issue.
Is there a reason to use such an old (and unsupported) version, or can it be updated?
