### PR TITLE
Enable MySQL Streaming

### DIFF
--- a/cascading-jdbc-core/src/main/java/cascading/jdbc/db/DBInputFormat.java
+++ b/cascading-jdbc-core/src/main/java/cascading/jdbc/db/DBInputFormat.java
@@ -81,9 +81,8 @@ public class DBInputFormat<T extends DBWritable> implements InputFormat<LongWrit
 
       if( connection == null )
         openConnection();
-      statement = connection.createStatement( ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY );
+      statement = createStatement();
 
-      // statement.setFetchSize(Integer.MIN_VALUE);
       String query = getSelectQuery();
       try
         {
@@ -97,6 +96,11 @@ public class DBInputFormat<T extends DBWritable> implements InputFormat<LongWrit
         throw new IOException( "unable to execute select query: " + query, exception );
         }
       }
+
+    protected Statement createStatement() throws SQLException {
+        Statement stmt = connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+        return stmt;
+    }
 
     /**
      * Returns the query for selecting the records, subclasses can override this

--- a/cascading-jdbc-mysql/src/main/java/cascading/jdbc/MySqlFactory.java
+++ b/cascading-jdbc-mysql/src/main/java/cascading/jdbc/MySqlFactory.java
@@ -23,7 +23,9 @@ package cascading.jdbc;
 import java.util.Properties;
 
 import cascading.jdbc.db.DBOutputFormat;
+import cascading.jdbc.db.DBInputFormat;
 import cascading.jdbc.db.MySqlDBOutputFormat;
+import cascading.jdbc.db.MySqlDBInputFormat;
 import cascading.scheme.Scheme;
 import cascading.tuple.Fields;
 
@@ -39,6 +41,12 @@ public class MySqlFactory extends JDBCFactory
     {
     return MySqlDBOutputFormat.class;
     }
+
+  @Override
+  protected Class<? extends DBInputFormat> getInputFormatClass()
+  {
+      return MySqlDBInputFormat.class;
+  }
 
   protected Scheme createUpdatableScheme( Fields fields, long limit, String[] columnNames, Boolean tableAlias, String conditions,
                                           String[] updateBy, Fields updateByFields, String[] orderBy, Properties properties )
@@ -56,4 +64,5 @@ public class MySqlFactory extends JDBCFactory
     {
     return new MySqlScheme( getInputFormatClass(), fields, columnNames, selectQuery, countQuery, limit, tableAlias);
     }
+
   }

--- a/cascading-jdbc-mysql/src/main/java/cascading/jdbc/db/MySqlDBInputFormat.java
+++ b/cascading-jdbc-mysql/src/main/java/cascading/jdbc/db/MySqlDBInputFormat.java
@@ -1,0 +1,62 @@
+/*
+* Copyright (c) 2007-2014 Concurrent, Inc. All Rights Reserved.
+*
+* Project and contact information: http://www.cascading.org/
+*
+* This file is part of the Cascading project.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package cascading.jdbc.db;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.*;
+
+import java.io.IOException;
+
+public class MySqlDBInputFormat<T extends DBWritable> extends DBInputFormat<T>
+{
+
+    protected class MySqlDBRecordReader extends DBRecordReader
+    {
+        protected MySqlDBRecordReader( DBInputSplit split, Class<T> inputClass, JobConf job ) throws SQLException, IOException
+        {
+            super(split, inputClass, job);
+        }
+
+        @Override
+        protected Statement createStatement() throws SQLException
+        {
+            Statement statement = connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+            statement.setFetchSize(Integer.MIN_VALUE);
+            return statement;
+        }
+    }
+
+    @Override
+    protected RecordReader<LongWritable, T> getRecordReaderInternal( DBInputSplit split, Class inputClass, JobConf job ) throws SQLException,
+            IOException
+    {
+        return new MySqlDBRecordReader( (DBInputSplit) split, inputClass, job );
+    }
+
+}


### PR DESCRIPTION
In Issue #21 the problem was that MySQL doesn't stream results.
The key issue here is that statement.setFetchSize(Integer.MIN_VALUE); needs to be performed on the statement in DBInputFormat's inner class DbRecordReader. And in the DBRecordReader's constructor there is the required change.

Before, the MySql client first read the complete result into ram and then handed it over to cascading. What you want is that results are streamed through the connection directly into cascading.

What I did:
- extract the "create statement" part into a method "createStatement()" so that it can be overriden by subclasses of DBRecordReader
- Created MySqlDBInputFormat which subclasses DBRecordReader and overloads the createStatement() and returns the according class (in getRecordReaderInternal)
- change MySqlFactory so that it returns the new MySqlDBInputFormat class
